### PR TITLE
Fix hydrogen to heavy when element changes are not allowed

### DIFF
--- a/lomap/mcs.py
+++ b/lomap/mcs.py
@@ -1234,7 +1234,7 @@ class MCS(object):
                                     hidx_i=ai
                                     hidx_j=aj
                                     best_dist=dist
-                if (hidx_i<0):
+                if (hidx_i<0) and self.options['element_change']:
                     # OK, no hydrogen-hydrogen matches left. Try to match a hydrogen to a non-hydrogen
                     for ai in attached_i:
                         for aj in attached_j:

--- a/lomap/mcs.py
+++ b/lomap/mcs.py
@@ -1234,7 +1234,7 @@ class MCS(object):
                                     hidx_i=ai
                                     hidx_j=aj
                                     best_dist=dist
-                if (hidx_i<0) and self.options['element_change']:
+                if (hidx_i < 0) and self.options['element_change']:
                     # OK, no hydrogen-hydrogen matches left. Try to match a hydrogen to a non-hydrogen
                     for ai in attached_i:
                         for aj in attached_j:

--- a/test/test_mcs.py
+++ b/test/test_mcs.py
@@ -311,3 +311,25 @@ def test_no_element_change(naphthol_explicit, methylnaphthalene_explicit,
     saw_oxygen = any(naphthol_explicit.GetAtomWithIdx(i).GetAtomicNum() == 8
                      for (i, _) in mapper.heavy_atom_mcs_map())
     assert saw_oxygen == element_change
+
+
+def test_no_element_change_hydrogen_to_heavy(toluene_explicit,
+                                             dimethylnaphthalene_explicit):
+    """
+    Checks that hydrogens in toluene are not matches to carbons in
+    dimethylnaphthalene
+    """
+    mapper = mcs.MCS(toluene_explicit, dimethylnaphthalene_explicit,
+                     threed=True, element_change=False)
+    expected_heavy = 7
+    expected_all = 13
+
+    assert len(mapper.heavy_atom_mcs_map()) == 7
+
+    mapping = mapper.all_atom_match_list().split(',')
+    mapping = [tuple(map(int, row.split(':'))) for row in mapping]
+
+    assert len(mapping) == expected_all
+    assert mapping == [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 10),
+                       (6, 11), (7, 12), (8, 13), (9, 14), (10, 15), (11, 16),
+                       (14, 23)]

--- a/test/test_mcs.py
+++ b/test/test_mcs.py
@@ -323,7 +323,7 @@ def test_no_element_change_hydrogen_to_heavy(toluene_explicit,
     """
     mapper = mcs.MCS(toluene_explicit, dimethylnaphthalene_explicit,
                      threed=True, element_change=element_change)
-    expected_heavy = 7 # 7 + 2 heavy to hydrogen
+    expected_heavy = 7  # 7 + 2 heavy to hydrogen
     expected_all = 15 if element_change else 13
 
     assert len(mapper.heavy_atom_mcs_map()) == expected_heavy

--- a/test/test_mcs.py
+++ b/test/test_mcs.py
@@ -313,23 +313,18 @@ def test_no_element_change(naphthol_explicit, methylnaphthalene_explicit,
     assert saw_oxygen == element_change
 
 
+@pytest.mark.parametrize('element_change', [True, False])
 def test_no_element_change_hydrogen_to_heavy(toluene_explicit,
-                                             dimethylnaphthalene_explicit):
+                                             dimethylnaphthalene_explicit,
+                                             element_change):
     """
     Checks that hydrogens in toluene are not matches to carbons in
     dimethylnaphthalene
     """
     mapper = mcs.MCS(toluene_explicit, dimethylnaphthalene_explicit,
-                     threed=True, element_change=False)
-    expected_heavy = 7
-    expected_all = 13
+                     threed=True, element_change=element_change)
+    expected_heavy = 7 # 7 + 2 heavy to hydrogen
+    expected_all = 15 if element_change else 13
 
-    assert len(mapper.heavy_atom_mcs_map()) == 7
-
-    mapping = mapper.all_atom_match_list().split(',')
-    mapping = [tuple(map(int, row.split(':'))) for row in mapping]
-
-    assert len(mapping) == expected_all
-    assert mapping == [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 10),
-                       (6, 11), (7, 12), (8, 13), (9, 14), (10, 15), (11, 16),
-                       (14, 23)]
+    assert len(mapper.heavy_atom_mcs_map()) == expected_heavy
+    assert len(mapper.all_atom_match_list().split(',')) == expected_all


### PR DESCRIPTION
Follow up from #14 

This is a bug @richardjgowers highlighted earlier this evening where hydrogens would still get mapped to heavy atoms even if element changes were not allowed.

Single line fix _should_ work here.