### PR TITLE
Explicitly decalre installation requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,15 @@ setup(
     platforms            = ['Linux-64', 'Mac OSX-64', 'Unix-64'],
     packages             = find_packages()+['test'],
     include_package_data = True,
-
+    install_requires     = [
+            'matplotlib~=3.5.2',
+            'networkx~=2.6.3',
+            'pygraphviz~=1.7',
+            'rdkit-pypi~=2022.3.3'
+    ],
+    extras_require       = {
+            'test': ['pytest~=7.1.2']
+    },
     entry_points         = {'console_scripts':['lomap=lomap.dbmol:startup']},
     zip_safe             = False
 )


### PR DESCRIPTION
Since Anaconda has recently required commercial users to pay for LICENSE, it becomes more important to offer a PYPI distribution or make it easy to **build from source**.

In this pull request, we explicitly declare required installation packages to follow the PYPI style and alleviate the pain of post-installation after importing failures of Lomap.

I have ran unit tests with the versions defined in change, so `~=` is used to tell newer versions of dependent packages are accepted as well.