### PR TITLE
TST: Re-enable some disabled tests

### DIFF
--- a/lomap/mcs.py
+++ b/lomap/mcs.py
@@ -90,10 +90,12 @@ class MCS(object):
             logging level, default 'info'
         max3d : float, optional
             The MCS is trimmed to remove atoms which are further apart than
-            this distance (in units of Angstrom), default 1,000.0
+            this distance (in units of Angstrom), default 1,000.0 (i.e. do
+            not trim)
         threed : bool, optional
-            Use the input 3D coordinates to guide the preferred MCS mappings,
-            default False
+            When disambiguating the substructure found back to the original
+            molecules, if True 3D coordinates are used, otherwise the number
+            of elemental changes is minimised. default False.
         element_change : bool, optional
             whether to allow elemental changes in mappings, default True
 

--- a/lomap/tests/test_lomap.py
+++ b/lomap/tests/test_lomap.py
@@ -18,7 +18,7 @@ def _rf(fn):
     return f
 
 
-@pytest.mark.parametrize('fn1, fn2, max3d_arg, threed_arg, exp_mcsr', [
+@pytest.mark.parametrize('fn1, fn2, threed_arg, max3d_arg, exp_mcsr', [
     (_rf('transforms/phenyl.sdf'), _rf('transforms/toluyl.sdf'), False, 1000, math.exp(-0.1 * (6 + 7 - 2*6))),
     (_rf('transforms/phenyl.sdf'), _rf('transforms/chlorophenyl.sdf'), False, 1000, math.exp(-0.1 * (6 + 7 - 2*6))),
     (_rf('transforms/toluyl.sdf'), _rf('transforms/chlorophenyl.sdf'), False, 1000, 1),
@@ -36,9 +36,7 @@ def _rf(fn):
    (_rf('transforms/chlorotoluyl1.sdf'), _rf('transforms/chlorotoluyl2.sdf'), False, 1000, 1),
    (_rf('transforms/chlorotoluyl1.sdf'), _rf('transforms/chlorotoluyl2.sdf'), True, 1000, 1)
 ])
-#@pytest.mark.skip("mcsr issue")
-def test_mcsr(fn1, fn2, max3d_arg, threed_arg, exp_mcsr):
-    # MolA, molB, 3D?, max3d, mcsr, atomic_number_rule
+def test_mcsr(fn1, fn2, threed_arg, max3d_arg, exp_mcsr):
     #logging.basicConfig(format='%(message)s', level=logging.DEBUG)
 
     lg = RDLogger.logger()

--- a/lomap/tests/test_lomap.py
+++ b/lomap/tests/test_lomap.py
@@ -36,16 +36,17 @@ def _rf(fn):
    (_rf('transforms/chlorotoluyl1.sdf'), _rf('transforms/chlorotoluyl2.sdf'), False, 1000, 1),
    (_rf('transforms/chlorotoluyl1.sdf'), _rf('transforms/chlorotoluyl2.sdf'), True, 1000, 1)
 ])
-@pytest.mark.skip("mcsr issue")
+#@pytest.mark.skip("mcsr issue")
 def test_mcsr(fn1, fn2, max3d_arg, threed_arg, exp_mcsr):
     # MolA, molB, 3D?, max3d, mcsr, atomic_number_rule
-    logging.basicConfig(format='%(message)s', level=logging.CRITICAL)
+    #logging.basicConfig(format='%(message)s', level=logging.DEBUG)
 
     lg = RDLogger.logger()
     lg.setLevel(RDLogger.CRITICAL)
 
     mola = Chem.MolFromMolFile(fn1, sanitize=False, removeHs=False)
-    molb = Chem.MolFromMolFile(fn1, sanitize=False, removeHs=False)
+    molb = Chem.MolFromMolFile(fn2, sanitize=False, removeHs=False)
+
     MC = MCS(mola, molb, time=20, verbose='info', max3d=max3d_arg, threed=threed_arg)
     mcsr = MC.mcsr()
 

--- a/lomap/tests/test_lomap.py
+++ b/lomap/tests/test_lomap.py
@@ -50,7 +50,7 @@ def test_mcsr(fn1, fn2, threed_arg, max3d_arg, exp_mcsr):
 
     assert mcsr == pytest.approx(exp_mcsr)
 
-@pytest.mark.parametrize('fn1, fn2, max3d_arg, threed_arg, exp_atnum', [
+@pytest.mark.parametrize('fn1, fn2, threed_arg, max3d_arg, exp_atnum', [
     (_rf('transforms/phenyl.sdf'), _rf('transforms/toluyl.sdf'), False, 1000, 1),
     (_rf('transforms/phenyl.sdf'), _rf('transforms/chlorophenyl.sdf'), False, 1000, 1),
     (_rf('transforms/toluyl.sdf'), _rf('transforms/chlorophenyl.sdf'), False, 1000, math.exp(-0.1 * 0.5)),
@@ -68,8 +68,7 @@ def test_mcsr(fn1, fn2, threed_arg, max3d_arg, exp_mcsr):
    (_rf('transforms/chlorotoluyl1.sdf'), _rf('transforms/chlorotoluyl2.sdf'), False, 1000, 1),
    (_rf('transforms/chlorotoluyl1.sdf'), _rf('transforms/chlorotoluyl2.sdf'), True, 1000, math.exp(-0.05 * 2))
 ])
-@pytest.mark.skip('atnum issue')
-def test_atnum_rule(fn1, fn2, max3d_arg, threed_arg, exp_atnum):
+def test_atnum_rule(fn1, fn2, threed_arg, max3d_arg, exp_atnum):
     # MolA, molB, 3D?, max3d, mcsr, atomic_number_rule
     logging.basicConfig(format='%(message)s', level=logging.CRITICAL)
 
@@ -77,7 +76,7 @@ def test_atnum_rule(fn1, fn2, max3d_arg, threed_arg, exp_atnum):
     lg.setLevel(RDLogger.CRITICAL)
 
     mola = Chem.MolFromMolFile(fn1, sanitize=False, removeHs=False)
-    molb = Chem.MolFromMolFile(fn1, sanitize=False, removeHs=False)
+    molb = Chem.MolFromMolFile(fn2, sanitize=False, removeHs=False)
     MC = MCS(mola, molb, time=20, verbose='info', max3d=max3d_arg, threed=threed_arg)
 
     atnum = MC.atomic_number_rule()


### PR DESCRIPTION
these were a little mangled in the pytest refactor, actual regression tests are unchanged