### PR TITLE
Switch from rdkit-pypi to rdkit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ python_requires = >= 3.8
 install_requires =
     matplotlib
     networkx
-    rdkit-pypi>=2021.*
+    rdkit>=2021.*
 
 include_package_data = True
 packages = find:


### PR DESCRIPTION
Simple one, as per: https://pypi.org/project/rdkit/ and https://pypi.org/project/rdkit-pypi/, rdkit-pypi is now deprecated in favour of just rdkit for pypi installs.