### PR TITLE
Update macos runner to macos-12

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
         rdkit-version: ["latest", ]
-        os: [ubuntu-latest, macos-11]
+        os: [ubuntu-latest, macos-12]
         include:
           - rdkit-version: "2021"
             python-version: "3.9"


### PR DESCRIPTION
macos-11 is deprecated and will be removed in ~ month