### PR TITLE
Avoid rdkit 2024.03.04

### DIFF
--- a/devtools/conda-envs/CI_env.yaml
+++ b/devtools/conda-envs/CI_env.yaml
@@ -5,7 +5,7 @@ dependencies:
   - networkx
   - numpy
   - matplotlib
-  - rdkit
+  - rdkit != 2024.03.4
   - pytest
   - codecov
   - gufe >= 0.10.0


### PR DESCRIPTION
CI has been failing for a bit since the 2024.03.04 release.