### PR TITLE
update network generation kwarg to match openfe (and deprecate)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@
 CHANGELOG
 *********
 
+Unreleased
+==========
+- Replaced the ``molecules`` argument with ``ligands`` in ``generate_lomap_network()``. Argument name ``molecules`` will be deprecated.
+
 2.3.0
 =====
 - Added shift option to MCS and cli (-s or --shift), this defaults to True.  In combination with threed/-3 this option

--- a/lomap/gufe_bindings/network_generation.py
+++ b/lomap/gufe_bindings/network_generation.py
@@ -9,7 +9,7 @@ import functools
 import logging
 import networkx as nx
 import numpy as np
-from typing import Callable, Optional, Union, Any
+from typing import Callable, Optional, Union, Any, Dict
 import warnings
 
 from ..graphgen import GraphGen
@@ -18,16 +18,27 @@ from .._due import due, Doi
 
 logger = logging.getLogger(__name__)
 
-def deprecated_kwarg(old_name:str, new_name:str):
+def rename_kwargs(func_name:str, kwargs:Dict[str, Any], old_name:str, new_name:str):
+    """Helper function for deprecating function arguments."""
+    if old_name in kwargs:
+        warnings.warn(f"{func_name} argument '{old_name}' is deprecated. Please use '{new_name}' instead.",
+                      DeprecationWarning)
+        kwargs[new_name] = kwargs.pop(old_name)
+    return kwargs
+
+def deprecated_kwarg(old_name:str, new_name:str) -> Callable:
+  """Decorator for deprecating keyword arguments
+
+  e.g.
+  @deprecated_kwarg(old_arg='new_arg')
+  def my_function(new_arg)
+      ...
+  """
   def decorator(func: Callable)->Callable:
-      # old_name = 'molecules'
-      # new_name = 'ligands'
+
       @functools.wraps(func)
       def wrapper(*args:Any, **kwargs:Any):
-          if old_name in kwargs:
-            kwargs[new_name] = kwargs.pop(old_name)
-            warnings.warn(f"{func.__name__} argument '{old_name}' is deprecated. Please use '{new_name}' instead.",
-                          DeprecationWarning)
+            kwargs = rename_kwargs(func.__name__, kwargs, old_name=old_name, new_name=new_name)
             return func(*args, **kwargs)
       return wrapper
   return decorator

--- a/lomap/gufe_bindings/network_generation.py
+++ b/lomap/gufe_bindings/network_generation.py
@@ -21,16 +21,20 @@ logger = logging.getLogger(__name__)
 def rename_kwargs(func_name:str, kwargs:Dict[str, Any], old_name:str, new_name:str):
     """Helper function for deprecating function arguments."""
     if old_name in kwargs:
-        warnings.warn(f"{func_name} argument '{old_name}' is deprecated. Please use '{new_name}' instead.",
+        if new_name in kwargs:
+            raise ValueError(f"Both {new_name} and {old_name} are defined for {func_name}. {old_name} is deprecated, please use {new_name} instead.")
+
+        else:
+          warnings.warn(f"{func_name} argument '{old_name}' is deprecated. Please use '{new_name}' instead.",
                       DeprecationWarning)
-        kwargs[new_name] = kwargs.pop(old_name)
+          kwargs[new_name] = kwargs.pop(old_name)
     return kwargs
 
 def deprecated_kwarg(old_name:str, new_name:str) -> Callable:
   """Decorator for deprecating keyword arguments
 
   e.g.
-  @deprecated_kwarg(old_arg='new_arg')
+  @deprecated_kwarg(old_arg, new_arg)
   def my_function(new_arg)
       ...
   """

--- a/lomap/gufe_bindings/network_generation.py
+++ b/lomap/gufe_bindings/network_generation.py
@@ -5,49 +5,18 @@ from gufe import(
 )
 import gufe
 import itertools
-import functools
 import logging
 import networkx as nx
 import numpy as np
-from typing import Callable, Optional, Union, Any, Dict
-import warnings
+from typing import Callable, Optional, Union
 
 from ..graphgen import GraphGen
 from .._due import due, Doi
-
+from ..utils import deprecated_kwargs
 
 logger = logging.getLogger(__name__)
 
-def rename_kwargs(func_name:str, kwargs:Dict[str, Any], old_name:str, new_name:str):
-    """Helper function for deprecating function arguments."""
-    if old_name in kwargs:
-        if new_name in kwargs:
-            raise ValueError(f"Both {new_name} and {old_name} are defined for {func_name}. {old_name} is deprecated, please use {new_name} instead.")
-
-        else:
-          warnings.warn(f"{func_name} argument '{old_name}' is deprecated. Please use '{new_name}' instead.",
-                      DeprecationWarning)
-          kwargs[new_name] = kwargs.pop(old_name)
-    return kwargs
-
-def deprecated_kwarg(old_name:str, new_name:str) -> Callable:
-  """Decorator for deprecating keyword arguments
-
-  e.g.
-  @deprecated_kwarg(old_arg, new_arg)
-  def my_function(new_arg)
-      ...
-  """
-  def decorator(func: Callable)->Callable:
-
-      @functools.wraps(func)
-      def wrapper(*args:Any, **kwargs:Any):
-            kwargs = rename_kwargs(func.__name__, kwargs, old_name=old_name, new_name=new_name)
-            return func(*args, **kwargs)
-      return wrapper
-  return decorator
-
-@deprecated_kwarg(old_name='molecules', new_name='ligands')
+@deprecated_kwargs(name_mappings={'molecules':'ligands'})
 @due.dcite(Doi("https://doi.org/10.1007/s10822-013-9678-y"), description="LOMAP")
 def generate_lomap_network(
         ligands: list[gufe.SmallMoleculeComponent],

--- a/lomap/tests/test_new_api.py
+++ b/lomap/tests/test_new_api.py
@@ -39,7 +39,7 @@ def test_generate_network_smoketest(basic):
         assert isinstance(network, gufe.LigandNetwork)
 
 
-def test_overdefined_generate_network(basic):
+def test_overdefined_deprecated_generate_network(basic):
     with pytest.raises(ValueError):
         lomap.generate_lomap_network(
             molecules=basic,

--- a/lomap/tests/test_new_api.py
+++ b/lomap/tests/test_new_api.py
@@ -38,3 +38,12 @@ def test_generate_network_smoketest(basic):
 
         assert isinstance(network, gufe.LigandNetwork)
 
+
+def test_overdefined_generate_network(basic):
+    with pytest.raises(ValueError):
+        lomap.generate_lomap_network(
+            molecules=basic,
+            ligands=basic,
+            mappers=lomap.LomapAtomMapper(),
+            scorer=lomap.default_lomap_score,
+        )

--- a/lomap/tests/test_new_api.py
+++ b/lomap/tests/test_new_api.py
@@ -29,7 +29,7 @@ def basic():
 
 
 def test_generate_network_smoketest(basic):
-    with pytest.deprecated_call():
+    with pytest.deprecated_call(match="'molecules' is deprecated, please use 'ligands'"):
         network = lomap.generate_lomap_network(
             molecules=basic,
             mappers=lomap.LomapAtomMapper(),
@@ -40,7 +40,7 @@ def test_generate_network_smoketest(basic):
 
 
 def test_overdefined_deprecated_generate_network(basic):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Both 'molecules' and 'ligands' are defined"):
         lomap.generate_lomap_network(
             molecules=basic,
             ligands=basic,

--- a/lomap/tests/test_new_api.py
+++ b/lomap/tests/test_new_api.py
@@ -29,10 +29,12 @@ def basic():
 
 
 def test_generate_network_smoketest(basic):
-    network = lomap.generate_lomap_network(
-        molecules=basic,
-        mappers=lomap.LomapAtomMapper(),
-        scorer=lomap.default_lomap_score,
-    )
+    with pytest.deprecated_call():
+        network = lomap.generate_lomap_network(
+            molecules=basic,
+            mappers=lomap.LomapAtomMapper(),
+            scorer=lomap.default_lomap_score,
+        )
 
-    assert isinstance(network, gufe.LigandNetwork)
+        assert isinstance(network, gufe.LigandNetwork)
+

--- a/lomap/utils.py
+++ b/lomap/utils.py
@@ -1,0 +1,45 @@
+import functools
+import warnings
+from typing import Any, Callable, Dict
+
+
+def rename_kwargs(func_name: str, kwargs: Dict[str, Any], name_mappings: Dict[str, str]):
+    """Helper function for deprecating function arguments."""
+    for old_name, new_name in name_mappings.items():
+        if old_name in kwargs:
+            if new_name in kwargs:
+                raise ValueError(
+                    f"Both {new_name} and {old_name} are defined for {func_name}."
+                    + f"{old_name} is deprecated, please use {new_name} instead."
+                )
+
+            else:
+                warnings.warn(
+                    f"{func_name} argument '{old_name}' is deprecated. Please use '{new_name}' instead.",
+                    DeprecationWarning,
+                )
+                kwargs[new_name] = kwargs.pop(old_name)
+        return kwargs
+
+
+def deprecated_kwargs(name_mappings: Dict[str, str]) -> Callable:
+    # TODO: make this work for multiple args
+    """Decorator for deprecating keyword arguments
+
+    e.g.
+    @deprecated_kwarg({'old_arg':'new_arg'})
+    def my_function(new_arg)
+        ...
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any):
+            kwargs = rename_kwargs(
+                func_name=func.__name__, kwargs=kwargs, name_mappings=name_mappings
+            )
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/lomap/utils.py
+++ b/lomap/utils.py
@@ -23,7 +23,6 @@ def rename_kwargs(func_name: str, kwargs: Dict[str, Any], name_mappings: Dict[st
 
 
 def deprecated_kwargs(name_mappings: Dict[str, str]) -> Callable:
-    # TODO: make this work for multiple args
     """Decorator for deprecating keyword arguments
 
     e.g.

--- a/lomap/utils.py
+++ b/lomap/utils.py
@@ -14,7 +14,7 @@ def rename_kwargs(
         if old_name in kwargs:
             if new_name in kwargs:
                 raise ValueError(
-                    f"Both '{new_name}' and '{old_name}' are defined for {func_name}."
+                    f"Both '{old_name}' and '{new_name}' are defined for {func_name}."
                     + f"'{old_name}' is deprecated, please use '{new_name}' instead."
                 )
 

--- a/lomap/utils.py
+++ b/lomap/utils.py
@@ -3,23 +3,25 @@ import warnings
 from typing import Any, Callable, Dict
 
 
-def rename_kwargs(func_name: str, kwargs: Dict[str, Any], name_mappings: Dict[str, str]):
+def rename_kwargs(
+    func_name: str, kwargs: Dict[str, Any], name_mappings: Dict[str, str]
+):
     """Helper function for deprecating function arguments."""
     for old_name, new_name in name_mappings.items():
+        deprecation_msg = (
+            f"{func_name} argument '{old_name}' is deprecated, please use '{new_name}' instead.",
+        )
         if old_name in kwargs:
             if new_name in kwargs:
                 raise ValueError(
-                    f"Both {new_name} and {old_name} are defined for {func_name}."
-                    + f"{old_name} is deprecated, please use {new_name} instead."
+                    f"Both '{new_name}' and '{old_name}' are defined for {func_name}."
+                    + f"'{old_name}' is deprecated, please use '{new_name}' instead."
                 )
 
             else:
-                warnings.warn(
-                    f"{func_name} argument '{old_name}' is deprecated. Please use '{new_name}' instead.",
-                    DeprecationWarning,
-                )
+                warnings.warn(deprecation_msg, DeprecationWarning)
                 kwargs[new_name] = kwargs.pop(old_name)
-        return kwargs
+    return kwargs
 
 
 def deprecated_kwargs(name_mappings: Dict[str, str]) -> Callable:


### PR DESCRIPTION
We want to rename `molecules` to `ligands` to match the openfe and konnektor naming conventions. 

Related to https://github.com/OpenFreeEnergy/openfe/issues/1070

Open to other methods of deprecation, I liked [this decorator approach.](https://stackoverflow.com/questions/49802412/how-to-implement-deprecation-in-python-with-argument-alias)