### PR TITLE
fix formatting bug

### DIFF
--- a/lomap/utils.py
+++ b/lomap/utils.py
@@ -8,9 +8,7 @@ def rename_kwargs(
 ):
     """Helper function for deprecating function arguments."""
     for old_name, new_name in name_mappings.items():
-        deprecation_msg = (
-            f"{func_name} argument '{old_name}' is deprecated, please use '{new_name}' instead.",
-        )
+        deprecation_msg = f"{func_name} argument '{old_name}' is deprecated, please use '{new_name}' instead."
         if old_name in kwargs:
             if new_name in kwargs:
                 raise ValueError(


### PR DESCRIPTION
A stray comma was causing the network generator deprecation warning to throw an error. 

This PR fixes the comma, but the remaining question is why the tests did not raise this error.