### PR TITLE
Adapt default charge change score to allow for charge changing transformations

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,4 +9,4 @@ Lomap API guide
 
 .. autofunction:: lomap.generate_lomap_network
 
-..autofunction:: lomap.default_lomap_score
+.. autofunction:: lomap.default_lomap_score

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,3 +8,5 @@ Lomap API guide
 
 
 .. autofunction:: lomap.generate_lomap_network
+
+..autofunction:: lomap.default_lomap_score

--- a/lomap/gufe_bindings/scorers.py
+++ b/lomap/gufe_bindings/scorers.py
@@ -411,7 +411,7 @@ def transmuting_ring_sizes_score(mapping: LigandAtomMapping) -> float:
 
 
 def default_lomap_score(mapping: LigandAtomMapping,
-                        charge_changes_score=0.0) -> float:
+                        charge_changes_score=0.1) -> float:
     """The default score function from Lomap2
 
 
@@ -426,7 +426,7 @@ def default_lomap_score(mapping: LigandAtomMapping,
     charge_changes_score: float
       The electrostatic score to be assigned for mappings of ligands that
       differ in net charge.
-      Default: 0.0 (e.g. not allowing net charge changes)
+      Default: 0.1 (e.g. allowing net charge changes)
 
     Returns
     -------

--- a/lomap/tests/test_scorer.py
+++ b/lomap/tests/test_scorer.py
@@ -36,7 +36,6 @@ def test_connected_lomap_network(smcs):
         mappers=lomap.LomapAtomMapper(),
         scorer=partial(lomap.default_lomap_score),
     )
-
     assert network.is_connected() == True
 
 
@@ -59,3 +58,13 @@ def test_ecr_consistency(smcs):
     assert_equal(score_zero, score_dbmol)
     assert not any(score_zero)
     assert all([i == 0.1 for i in score_nonzero])
+
+
+def test_default_and_explicit_charge_change_score_same(smcs):
+    mapper = lomap.LomapAtomMapper()
+    mapping = next(mapper.suggest_mappings(smcs[0], smcs[1]))
+    result_default = lomap.default_lomap_score(mapping)
+    result_explicit = lomap.default_lomap_score(mapping,
+                                                charge_changes_score=0.1)
+
+    assert result_default == result_explicit

--- a/lomap/tests/test_scorer.py
+++ b/lomap/tests/test_scorer.py
@@ -29,10 +29,12 @@ def test_unconnected_lomap_network(smcs):
 
 
 def test_connected_lomap_network(smcs):
+    # The default charge_changes_score is now 0.1, so a network of ligands
+    # with different net charges should now always be connected
     network = lomap.generate_lomap_network(
         molecules=smcs,
         mappers=lomap.LomapAtomMapper(),
-        scorer=partial(lomap.default_lomap_score, charge_changes_score=0.1),
+        scorer=partial(lomap.default_lomap_score),
     )
 
     assert network.is_connected() == True

--- a/news/TEMPLATE.rst
+++ b/news/TEMPLATE.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/charge_change_score.rst
+++ b/news/charge_change_score.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* Changed the default `charge_changes_score` from 0.0 to 0.1 in the gufe bindings to enable connected networks for 
+* Changed the default ``charge_changes_score`` from 0.0 to 0.1 in the gufe bindings to enable connected networks for 
   ligands of different net charge by default.
 
 **Deprecated:**

--- a/news/charge_change_score.rst
+++ b/news/charge_change_score.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Changed the default `charge_changes_score` from 0.0 to 0.1 in the gufe bindings to enable connected networks for 
+  ligands of different net charge by default.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Only adapt this in gufe bindings to not affect main Lomap behaviour.

- [x] Check if docs have to be updated
 ---> The scorers are not part of the API documentation?!