### PR TITLE
fix docs memory build error

### DIFF
--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -2,14 +2,10 @@ name: lomap-docs
 channels:
 - https://conda.anaconda.org/conda-forge
 dependencies:
-# - openff-units==0.2.0
-# - plugcli
 - pydata-sphinx-theme
 - python=3.10
-# - sphinx
-# - tqdm
 - gufe>=1.6.1
 - pip:
   - sphinx-design
   - sphinx-toolbox
-  - git+https://github.com/OpenFreeEnergy/ofe-sphinx-theme@main
+  - git+https://github.com/OpenFreeEnergy/ofe-sphinx-theme@v0.2.0


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
RTD build is failing because the build requires too much memory - we should be able to trim this down.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->


## Checklist
* [ ] Added a ``news`` entry
<!-- see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command) -->

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
