### PR TITLE
update CI workflow versions

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
         rdkit-version: ["latest"]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-15-intel, macos-latest]
         include:
           - rdkit-version: "2021"
             python-version: "3.9"


### PR DESCRIPTION
[macos-13 runners are deprecated.](https://github.com/actions/runner-images/issues/13046) I also bumped the python versions according to SPEC0/ the rest of the openfe ecosystem.

Not sure if we still want to be testing against rdkit 2021 - @IAlibay ?