### PR TITLE
Doc Improvement for `generate_lomap_network`

### DIFF
--- a/lomap/gufe_bindings/network_generation.py
+++ b/lomap/gufe_bindings/network_generation.py
@@ -44,13 +44,13 @@ def generate_lomap_network(
        to 0.0 (worst).  These values are use as the "distance" between two molecules, and compared against the
        'distance_cutoff' parameter
     distance_cutoff : float
-       the maximum distance/dissimilarity between two molecules for an edge to be accepted
+       edges with a score >= 1 - distance_cutoff will be accepted. Default is 0.4.
     max_path_length : int
-      maximum distance between any two molecules in the resulting network
+      maximum distance between any two molecules in the resulting network. Default is 6.
     actives : list[bool]
-      for each molecule, if it is tagged as an active molecule
+      for each molecule, if it is tagged as an active molecule 
     max_dist_from_active
-      when 'actives' is given, constrains the resulting map to
+      when 'actives' is given, constrains the resulting map to be within this distance from an active molecule. Default is 2.
     require_cycle_covering : bool
       add cycles into the network
     radial : bool

--- a/lomap/gufe_bindings/network_generation.py
+++ b/lomap/gufe_bindings/network_generation.py
@@ -50,7 +50,7 @@ def generate_lomap_network(
     actives : list[bool]
       for each molecule, if it is tagged as an active molecule 
     max_dist_from_active
-      when 'actives' is given, constrains the resulting map to be within this distance from an active molecule. Default is 2.
+      when 'actives' is given, constrains the resulting map to be within this this number of edges (e.g. distance) from an active molecule. Default is 2.
     require_cycle_covering : bool
       add cycles into the network
     radial : bool

--- a/lomap/gufe_bindings/network_generation.py
+++ b/lomap/gufe_bindings/network_generation.py
@@ -44,7 +44,7 @@ def generate_lomap_network(
        to 0.0 (worst).  These values are use as the "distance" between two molecules, and compared against the
        'distance_cutoff' parameter
     distance_cutoff : float
-       edges with a score >= 1 - distance_cutoff will be accepted. Default is 0.4.
+       edges with a score < 1 - distance_cutoff will be rejected. Default is 0.4.
     max_path_length : int
       maximum distance between any two molecules in the resulting network. Default is 6.
     actives : list[bool]


### PR DESCRIPTION
I noticed some incomplete and some unclear docs for `generate_lomap_network` so went ahead and fixed them. 

If maintainers are interested I can also push a fix of several type errors in `lomap/gufe_bindings/network_generation.py`