### PR TITLE
add CHANGELOG in index - fix docs build

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Lomap (Lead Optimization Mapper) is a tool for planning perturbation networks fo
    api.rst
    legacy.rst
    citing.rst
+   CHANGELOG.rst
 
 
 


### PR DESCRIPTION
Adding CHANGELOG.rst to the index so that docs don't break with a warning (and so the CHANGELOG is included in the docs!)