### PR TITLE
let setuptools auto detect pkg layout and remove deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,6 @@ urls = {Homepage = "https://github.com/OpenFreeEnergy/Lomap"}
 keywords = ['alchemical free energy', 'setup', 'perturbation', 'network']
 requires-python = ">= 3.9"
 dependencies = [
-    "numpy",
-    "networkx",
-    "matplotlib",
-    "rdkit",
-    "gufe>=0.9.0",
 ]
 dynamic = ["version"]
 
@@ -54,9 +49,6 @@ lomap = "lomap.dbmol:startup"
 [tool.setuptools]
 zip-safe = false
 include-package-data = true
-
-[tool.setuptools.packages]
-find = {namespaces = false}
 
 [tool.setuptools_scm]
 fallback_version = "0.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 authors = [{name = "Gaetano Calabro and David Mobley"}]
 maintainers = [{name = "The Open Free Energy developers", email = "openfreeenergy@omsf.io"}]
 license = "MIT"
-license-files = ["LICENSE"]
+license-files = ["LICENSE.txt"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",


### PR DESCRIPTION
fixes regression to `src/` layout. `setuptools` didn't detect a `src/` layout and created an empty package. 

This also removes the deps from the `pyproject.toml` which are a footgun since it can then install a very old version of `gufe`. 