### PR TITLE
Make gufe optional

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: "Install optional gufe"
         if: ${{ matrix.gufe == 'yes' }}
         run: |
-          micromamba install -c conda-forge gufe
+          micromamba install -c conda-forge "gufe>1.0"
 
       - name: Install package
         run: python -m pip install --no-deps -v -e .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: "Install optional gufe"
         if: ${{ matrix.gufe == 'yes' }}
         run: |
-          micromamba install -c conda-forge "gufe>1.6.1"
+          micromamba install -c conda-forge "gufe>=1.6.1"
 
       - name: Install package
         run: python -m pip install --no-deps -v -e .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ defaults:
 
 jobs:
   test:
-    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    name: Test on ${{ matrix.os }}, Python: ${{ matrix.python-version }}, Gufe: ${{ matrix.gufe }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -65,7 +65,7 @@ jobs:
       - name: "Install optional gufe"
         if: ${{ matrix.gufe == 'yes' }}
         run: |
-          micromamba install -c conda-forge "gufe>1.0"
+          micromamba install -c conda-forge "gufe>1.6.1"
 
       - name: Install package
         run: python -m pip install --no-deps -v -e .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,11 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-15-intel, macos-latest]
+        gufe: ["yes"]
+        include:
+          - os: "ubuntu-latest"
+            python-version: "3.12"
+            gufe: "no"
 
     steps:
       - uses: actions/checkout@v6
@@ -56,6 +61,11 @@ jobs:
           create-args: >-
             python=${{ matrix.python-version }}
           init-shell: bash
+
+      - name: "Install optional gufe"
+        if: ${{ matrix.gufe == 'yes' }}
+        run: |
+          micromamba install -c conda-forge gufe
 
       - name: Install package
         run: python -m pip install --no-deps -v -e .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ defaults:
 
 jobs:
   test:
-    name: Test on ${{ matrix.os }}, Python: ${{ matrix.python-version }}, Gufe: ${{ matrix.gufe }}
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}, Gufe ${{ matrix.gufe }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -40,6 +40,7 @@ jobs:
             python=3.12
             mypy
             types-networkx
+            gufe>=1.6.1
           init-shell: bash
 
       - name: "Install steps"

--- a/environment.yaml
+++ b/environment.yaml
@@ -8,4 +8,3 @@ dependencies:
   - rdkit != 2024.03.4
   - pytest
   - codecov
-  - gufe >= 1.0

--- a/news/optional-gufe.rst
+++ b/news/optional-gufe.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* The `gufe` package is now an optional dependency of Lomap (PR #134).
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/lomap/gufe_bindings/mapper.py
+++ b/src/lomap/gufe_bindings/mapper.py
@@ -2,7 +2,9 @@
 The MCS class wrapped to provide a gufe interface
 
 """
+
 from __future__ import annotations
+
 from collections.abc import Iterable
 
 try:
@@ -12,8 +14,8 @@ except ImportError:
     AtomMapper = object
 
 from lomap import mcs as lomap_mcs
-from lomap.utils import requires_package
 from lomap._due import Doi, due
+from lomap.utils import requires_package
 
 
 @requires_package("gufe")

--- a/src/lomap/gufe_bindings/mapper.py
+++ b/src/lomap/gufe_bindings/mapper.py
@@ -9,8 +9,6 @@ try:
     from gufe import AtomMapper, LigandAtomMapping, SmallMoleculeComponent
 except ImportError:
     AtomMapper = object  # Empty class type to make subclassing simpler
-    # LigandAtomMapping = None
-    # SmallMoleculeComponent = None
 
 from lomap import mcs as lomap_mcs
 from lomap.utils import requires_package

--- a/src/lomap/gufe_bindings/mapper.py
+++ b/src/lomap/gufe_bindings/mapper.py
@@ -6,10 +6,11 @@ The MCS class wrapped to provide a gufe interface
 from collections.abc import Iterable
 
 try:
-    import gufe
-    from gufe import AtomMapper, LigandAtomMapping
+    from gufe import AtomMapper, LigandAtomMapping, SmallMoleculeComponent
 except ImportError:
-    pass
+    AtomMapper = None  # type: ignore[assignment,misc]
+    LigandAtomMapping = None  # type: ignore[assignment,misc]
+    SmallMoleculeComponent = None  # type: ignore[assignment,misc]
 
 from lomap import mcs as lomap_mcs
 from lomap.utils import requires_package
@@ -94,7 +95,7 @@ class LomapAtomMapper(AtomMapper):
 
     @due.dcite(Doi("https://doi.org/10.1007/s10822-013-9678-y"), description="LOMAP")
     def suggest_mappings(
-        self, componentA: gufe.SmallMoleculeComponent, componentB: gufe.SmallMoleculeComponent
+        self, componentA: SmallMoleculeComponent, componentB: SmallMoleculeComponent
     ) -> Iterable[LigandAtomMapping]:
         """Generate one or more mappings between two small molecules
 

--- a/src/lomap/gufe_bindings/mapper.py
+++ b/src/lomap/gufe_bindings/mapper.py
@@ -8,7 +8,8 @@ from collections.abc import Iterable
 try:
     from gufe import AtomMapper, LigandAtomMapping, SmallMoleculeComponent
 except ImportError:
-    AtomMapper = object  # Empty class type to make subclassing simpler
+    # Need to have a definition for the class to avoid subclass failure
+    AtomMapper = object
 
 from lomap import mcs as lomap_mcs
 from lomap.utils import requires_package

--- a/src/lomap/gufe_bindings/mapper.py
+++ b/src/lomap/gufe_bindings/mapper.py
@@ -2,7 +2,7 @@
 The MCS class wrapped to provide a gufe interface
 
 """
-
+from __future__ import annotations
 from collections.abc import Iterable
 
 try:

--- a/src/lomap/gufe_bindings/mapper.py
+++ b/src/lomap/gufe_bindings/mapper.py
@@ -8,9 +8,9 @@ from collections.abc import Iterable
 try:
     from gufe import AtomMapper, LigandAtomMapping, SmallMoleculeComponent
 except ImportError:
-    AtomMapper = None  # type: ignore[assignment,misc]
-    LigandAtomMapping = None  # type: ignore[assignment,misc]
-    SmallMoleculeComponent = None  # type: ignore[assignment,misc]
+    AtomMapper = object  # Empty class type to make subclassing simpler
+    LigandAtomMapping = None
+    SmallMoleculeComponent = None
 
 from lomap import mcs as lomap_mcs
 from lomap.utils import requires_package

--- a/src/lomap/gufe_bindings/mapper.py
+++ b/src/lomap/gufe_bindings/mapper.py
@@ -8,8 +8,7 @@ from collections.abc import Iterable
 try:
     from gufe import AtomMapper, LigandAtomMapping, SmallMoleculeComponent
 except ImportError:
-    pass
-    # AtomMapper = object  # Empty class type to make subclassing simpler
+    AtomMapper = object  # Empty class type to make subclassing simpler
     # LigandAtomMapping = None
     # SmallMoleculeComponent = None
 

--- a/src/lomap/gufe_bindings/mapper.py
+++ b/src/lomap/gufe_bindings/mapper.py
@@ -5,13 +5,18 @@ The MCS class wrapped to provide a gufe interface
 
 from collections.abc import Iterable
 
-import gufe
-from gufe import AtomMapper, LigandAtomMapping
+try:
+    import gufe
+    from gufe import AtomMapper, LigandAtomMapping
+except ImportError:
+    pass
 
-from .. import mcs as lomap_mcs
-from .._due import Doi, due
+from lomap import mcs as lomap_mcs
+from lomap.utils import requires_package
+from lomap._due import Doi, due
 
 
+@requires_package("gufe")
 class LomapAtomMapper(AtomMapper):
     time: int
     threed: bool

--- a/src/lomap/gufe_bindings/mapper.py
+++ b/src/lomap/gufe_bindings/mapper.py
@@ -8,9 +8,10 @@ from collections.abc import Iterable
 try:
     from gufe import AtomMapper, LigandAtomMapping, SmallMoleculeComponent
 except ImportError:
-    AtomMapper = object  # Empty class type to make subclassing simpler
-    LigandAtomMapping = None
-    SmallMoleculeComponent = None
+    pass
+    # AtomMapper = object  # Empty class type to make subclassing simpler
+    # LigandAtomMapping = None
+    # SmallMoleculeComponent = None
 
 from lomap import mcs as lomap_mcs
 from lomap.utils import requires_package

--- a/src/lomap/gufe_bindings/network_generation.py
+++ b/src/lomap/gufe_bindings/network_generation.py
@@ -13,10 +13,10 @@ try:
         SmallMoleculeComponent,
     )
 except ImportError:
-    AtomMapper = None  # type: ignore[assignment,misc]
-    LigandAtomMapping = None  # type: ignore[assignment,misc]
-    LigandNetwork = None  # type: ignore[assignment,misc]
-    SmallMoleculeComponent = None  # type: ignore[assignment,misc]
+    AtomMapper = None
+    LigandAtomMapping = None
+    LigandNetwork = None
+    SmallMoleculeComponent = None
 
 from lomap._due import Doi, due
 from lomap.graphgen import GraphGen

--- a/src/lomap/gufe_bindings/network_generation.py
+++ b/src/lomap/gufe_bindings/network_generation.py
@@ -15,10 +15,6 @@ try:
     )
 except ImportError:
     pass
-    # AtomMapper = None
-    # LigandAtomMapping = None
-    # LigandNetwork = None
-    # SmallMoleculeComponent = None
 
 from lomap._due import Doi, due
 from lomap.graphgen import GraphGen

--- a/src/lomap/gufe_bindings/network_generation.py
+++ b/src/lomap/gufe_bindings/network_generation.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import itertools
 import logging
 from collections.abc import Callable

--- a/src/lomap/gufe_bindings/network_generation.py
+++ b/src/lomap/gufe_bindings/network_generation.py
@@ -2,22 +2,27 @@ import itertools
 import logging
 from collections.abc import Callable
 
-import gufe
 import networkx as nx
 import numpy as np
-from gufe import (
-    AtomMapper,
-    LigandAtomMapping,
-    LigandNetwork,
-)
 
-from .._due import Doi, due
-from ..graphgen import GraphGen
-from ..utils import deprecated_kwargs
+try:
+    import gufe
+    from gufe import (
+        AtomMapper,
+        LigandAtomMapping,
+        LigandNetwork,
+    )
+except ImportError:
+    pass
+
+from lomap._due import Doi, due
+from lomap.graphgen import GraphGen
+from lomap.utils import deprecated_kwargs, requires_package
 
 logger = logging.getLogger(__name__)
 
 
+@requires_package("gufe")
 @deprecated_kwargs(name_mappings={"molecules": "ligands"})
 @due.dcite(Doi("https://doi.org/10.1007/s10822-013-9678-y"), description="LOMAP")
 def generate_lomap_network(

--- a/src/lomap/gufe_bindings/network_generation.py
+++ b/src/lomap/gufe_bindings/network_generation.py
@@ -14,10 +14,11 @@ try:
         SmallMoleculeComponent,
     )
 except ImportError:
-    AtomMapper = None
-    LigandAtomMapping = None
-    LigandNetwork = None
-    SmallMoleculeComponent = None
+    pass
+    # AtomMapper = None
+    # LigandAtomMapping = None
+    # LigandNetwork = None
+    # SmallMoleculeComponent = None
 
 from lomap._due import Doi, due
 from lomap.graphgen import GraphGen

--- a/src/lomap/gufe_bindings/network_generation.py
+++ b/src/lomap/gufe_bindings/network_generation.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import itertools
 import logging
 from collections.abc import Callable

--- a/src/lomap/gufe_bindings/network_generation.py
+++ b/src/lomap/gufe_bindings/network_generation.py
@@ -6,14 +6,17 @@ import networkx as nx
 import numpy as np
 
 try:
-    import gufe
     from gufe import (
         AtomMapper,
         LigandAtomMapping,
         LigandNetwork,
+        SmallMoleculeComponent,
     )
 except ImportError:
-    pass
+    AtomMapper = None  # type: ignore[assignment,misc]
+    LigandAtomMapping = None  # type: ignore[assignment,misc]
+    LigandNetwork = None  # type: ignore[assignment,misc]
+    SmallMoleculeComponent = None  # type: ignore[assignment,misc]
 
 from lomap._due import Doi, due
 from lomap.graphgen import GraphGen
@@ -26,7 +29,7 @@ logger = logging.getLogger(__name__)
 @deprecated_kwargs(name_mappings={"molecules": "ligands"})
 @due.dcite(Doi("https://doi.org/10.1007/s10822-013-9678-y"), description="LOMAP")
 def generate_lomap_network(
-    ligands: list[gufe.SmallMoleculeComponent],
+    ligands: list[SmallMoleculeComponent],
     mappers: AtomMapper | list[AtomMapper],
     scorer: Callable,
     distance_cutoff: float = 0.4,
@@ -36,7 +39,7 @@ def generate_lomap_network(
     require_cycle_covering: bool = True,
     radial: bool = False,
     fast: bool = False,
-    hub: gufe.SmallMoleculeComponent | None = None,
+    hub: SmallMoleculeComponent | None = None,
 ) -> LigandNetwork:
     """Generate a LigandNetwork according to Lomap's network creation rules
 
@@ -71,7 +74,7 @@ def generate_lomap_network(
     """
     if not mappers:
         raise ValueError("At least one Mapper must be provided")
-    if isinstance(mappers, gufe.AtomMapper):
+    if isinstance(mappers, AtomMapper):
         mappers = [mappers]
     if actives is None:
         actives = [False] * len(ligands)

--- a/src/lomap/gufe_bindings/scorers.py
+++ b/src/lomap/gufe_bindings/scorers.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import math
 from collections import defaultdict
 

--- a/src/lomap/gufe_bindings/scorers.py
+++ b/src/lomap/gufe_bindings/scorers.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import math
 from collections import defaultdict
 

--- a/src/lomap/gufe_bindings/scorers.py
+++ b/src/lomap/gufe_bindings/scorers.py
@@ -6,7 +6,7 @@ from rdkit import Chem
 try:
     from gufe import LigandAtomMapping
 except ImportError:
-    pass
+    LigandAtomMapping = None  # type: ignore[assignment,misc]
 
 from lomap import dbmol as _dbmol
 from lomap import mcs as lomap_mcs

--- a/src/lomap/gufe_bindings/scorers.py
+++ b/src/lomap/gufe_bindings/scorers.py
@@ -103,7 +103,7 @@ def mncar_score(mapping: LigandAtomMapping, ths: int = 4) -> float:
 
 
 @requires_package("gufe")
-def tmcsr_score(self, mapping: LigandAtomMapping):
+def tmcsr_score(mapping: LigandAtomMapping):
     raise NotImplementedError
 
 

--- a/src/lomap/gufe_bindings/scorers.py
+++ b/src/lomap/gufe_bindings/scorers.py
@@ -1,8 +1,12 @@
 import math
 from collections import defaultdict
 
-from gufe import LigandAtomMapping
 from rdkit import Chem
+
+try:
+    from gufe import LigandAtomMapping
+except ImportError:
+    pass
 
 from lomap import dbmol as _dbmol
 from lomap import mcs as lomap_mcs

--- a/src/lomap/gufe_bindings/scorers.py
+++ b/src/lomap/gufe_bindings/scorers.py
@@ -8,10 +8,10 @@ try:
     from gufe import LigandAtomMapping
 except ImportError:
     pass
-    # LigandAtomMapping = None
 
 from lomap import dbmol as _dbmol
 from lomap import mcs as lomap_mcs
+from lomap.utils import requires_package
 
 DEFAULT_ANS_DIFFICULTY = {
     # H to element - not sure this has any effect currently
@@ -27,6 +27,7 @@ DEFAULT_ANS_DIFFICULTY = {
 }
 
 
+@requires_package("gufe")
 def ecr_score(mapping: LigandAtomMapping, charge_changes_score) -> float:
     molA = mapping.componentA.to_rdkit()
     molB = mapping.componentB.to_rdkit()
@@ -40,6 +41,7 @@ def ecr_score(mapping: LigandAtomMapping, charge_changes_score) -> float:
         return charge_changes_score
 
 
+@requires_package("gufe")
 def mcsr_score(mapping: LigandAtomMapping, beta: float = 0.1) -> float:
     """Maximum command substructure rule
 
@@ -72,6 +74,7 @@ def mcsr_score(mapping: LigandAtomMapping, beta: float = 0.1) -> float:
     return mcsr
 
 
+@requires_package("gufe")
 def mncar_score(mapping: LigandAtomMapping, ths: int = 4) -> float:
     """Minimum number of common atoms rule
 
@@ -99,10 +102,12 @@ def mncar_score(mapping: LigandAtomMapping, ths: int = 4) -> float:
     return 1.0 if ok else 0.0
 
 
+@requires_package("gufe")
 def tmcsr_score(self, mapping: LigandAtomMapping):
     raise NotImplementedError
 
 
+@requires_package("gufe")
 def atomic_number_score(mapping: LigandAtomMapping, beta=0.1, difficulty=None) -> float:
     """A score on the elemental changes happening in the mapping
 
@@ -166,6 +171,7 @@ def atomic_number_score(mapping: LigandAtomMapping, beta=0.1, difficulty=None) -
     return math.exp(-beta * nmismatch)
 
 
+@requires_package("gufe")
 def hybridization_score(mapping: LigandAtomMapping, beta=0.15) -> float:
     """
 
@@ -215,6 +221,7 @@ def hybridization_score(mapping: LigandAtomMapping, beta=0.15) -> float:
     return math.exp(-beta * nmismatch)
 
 
+@requires_package("gufe")
 def sulfonamides_score(mapping: LigandAtomMapping, beta=0.4) -> float:
     """Checks if a sulfonamide appears and disallow this.
 
@@ -257,6 +264,7 @@ def sulfonamides_score(mapping: LigandAtomMapping, beta=0.4) -> float:
         return 1.0
 
 
+@requires_package("gufe")
 def heterocycles_score(mapping: LigandAtomMapping, beta=0.4) -> float:
     """Checks if a heterocycle is formed from a -H
 
@@ -299,6 +307,7 @@ def heterocycles_score(mapping: LigandAtomMapping, beta=0.4) -> float:
         return 1.0
 
 
+@requires_package("gufe")
 def transmuting_methyl_into_ring_score(mapping: LigandAtomMapping, beta=0.1, penalty=6.0) -> float:
     """Penalises having a non-mapped ring atoms become a non-ring
 
@@ -360,6 +369,7 @@ def transmuting_methyl_into_ring_score(mapping: LigandAtomMapping, beta=0.1, pen
         return math.exp(-beta * penalty)
 
 
+@requires_package("gufe")
 def transmuting_ring_sizes_score(mapping: LigandAtomMapping) -> float:
     """Checks if mapping alters a ring size"""
     molA = mapping.componentA.to_rdkit()
@@ -412,6 +422,7 @@ def transmuting_ring_sizes_score(mapping: LigandAtomMapping) -> float:
     return 0.1 if is_bad else 1.0
 
 
+@requires_package("gufe")
 def default_lomap_score(mapping: LigandAtomMapping, charge_changes_score=0.1) -> float:
     """The default score function from Lomap2
 

--- a/src/lomap/gufe_bindings/scorers.py
+++ b/src/lomap/gufe_bindings/scorers.py
@@ -7,7 +7,8 @@ from rdkit import Chem
 try:
     from gufe import LigandAtomMapping
 except ImportError:
-    LigandAtomMapping = None
+    pass
+    # LigandAtomMapping = None
 
 from lomap import dbmol as _dbmol
 from lomap import mcs as lomap_mcs

--- a/src/lomap/gufe_bindings/scorers.py
+++ b/src/lomap/gufe_bindings/scorers.py
@@ -6,7 +6,7 @@ from rdkit import Chem
 try:
     from gufe import LigandAtomMapping
 except ImportError:
-    LigandAtomMapping = None  # type: ignore[assignment,misc]
+    LigandAtomMapping = None
 
 from lomap import dbmol as _dbmol
 from lomap import mcs as lomap_mcs

--- a/src/lomap/tests/test_lomapatommapper.py
+++ b/src/lomap/tests/test_lomapatommapper.py
@@ -1,6 +1,14 @@
+import pytest
 from lomap import LomapAtomMapper
 
+try:
+    import gufe
+    HAS_GUFE = True
+except ImportError:
+    HAS_GUFE = False
 
+
+@pytest.mark.skipif(not HAS_GUFE, reason="requires gufe installed")
 def test_to_dict_roundtrip():
     ref_vals = {
         "time": 19,
@@ -26,6 +34,7 @@ def test_to_dict_roundtrip():
     assert m2.shift == ref_vals["shift"]
 
 
+@pytest.mark.skipif(not HAS_GUFE, reason="requires gufe installed")
 def test_repr():
     m = LomapAtomMapper()
 

--- a/src/lomap/tests/test_lomapatommapper.py
+++ b/src/lomap/tests/test_lomapatommapper.py
@@ -1,8 +1,10 @@
 import pytest
+
 from lomap import LomapAtomMapper
 
 try:
     import gufe
+
     HAS_GUFE = True
 except ImportError:
     HAS_GUFE = False

--- a/src/lomap/tests/test_lomapatommapper.py
+++ b/src/lomap/tests/test_lomapatommapper.py
@@ -10,7 +10,7 @@ except ImportError:
 
 @pytest.mark.skipif(HAS_GUFE, reason="requires not having gufe installed")
 def test_lomap_atommaper_no_gufe_error():
-    msg = "gufe is required to use `LomapAtomMapper`"
+    msg = "gufe is required to use `LomapAtomMapper` but is not installed."
     with pytest.raises(ImportError, match=msg):
         _ = LomapAtomMapper()
 

--- a/src/lomap/tests/test_lomapatommapper.py
+++ b/src/lomap/tests/test_lomapatommapper.py
@@ -8,6 +8,12 @@ except ImportError:
     HAS_GUFE = False
 
 
+@pytest.mark.skipif(HAS_GUFE, reason="requires not having gufe installed")
+def test_lomap_atommaper_no_gufe_error():
+    with pytest.raises(ImportError, match="gufe is required to use"):
+        _ = LomapAtomMapper()
+
+
 @pytest.mark.skipif(not HAS_GUFE, reason="requires gufe installed")
 def test_to_dict_roundtrip():
     ref_vals = {

--- a/src/lomap/tests/test_lomapatommapper.py
+++ b/src/lomap/tests/test_lomapatommapper.py
@@ -10,7 +10,8 @@ except ImportError:
 
 @pytest.mark.skipif(HAS_GUFE, reason="requires not having gufe installed")
 def test_lomap_atommaper_no_gufe_error():
-    with pytest.raises(ImportError, match="gufe is required to use"):
+    msg = "gufe is required to use LomapAtomMapper"
+    with pytest.raises(ImportError, match=msg):
         _ = LomapAtomMapper()
 
 

--- a/src/lomap/tests/test_lomapatommapper.py
+++ b/src/lomap/tests/test_lomapatommapper.py
@@ -10,7 +10,7 @@ except ImportError:
 
 @pytest.mark.skipif(HAS_GUFE, reason="requires not having gufe installed")
 def test_lomap_atommaper_no_gufe_error():
-    msg = "gufe is required to use LomapAtomMapper"
+    msg = "gufe is required to use `LomapAtomMapper`"
     with pytest.raises(ImportError, match=msg):
         _ = LomapAtomMapper()
 

--- a/src/lomap/tests/test_new_api.py
+++ b/src/lomap/tests/test_new_api.py
@@ -1,10 +1,15 @@
 import importlib.resources
 
-import gufe
 import pytest
 from rdkit import Chem
 
 import lomap
+
+try:
+    import gufe
+    HAS_GUFE = True
+except ImportError:
+    HAS_GUFE = False
 
 
 @pytest.fixture
@@ -29,7 +34,7 @@ def basic():
 
     return mols
 
-
+@pytest.mark.skipif(not HAS_GUFE, reason="requires gufe installed")
 def test_generate_network_smoketest(basic):
     with pytest.deprecated_call(match="'molecules' is deprecated, please use 'ligands'"):
         network = lomap.generate_lomap_network(
@@ -41,6 +46,7 @@ def test_generate_network_smoketest(basic):
         assert isinstance(network, gufe.LigandNetwork)
 
 
+@pytest.mark.skipif(not HAS_GUFE, reason="requires gufe installed")
 def test_overdefined_deprecated_generate_network(basic):
     with pytest.raises(ValueError, match="Both 'molecules' and 'ligands' are defined"):
         lomap.generate_lomap_network(

--- a/src/lomap/tests/test_new_api.py
+++ b/src/lomap/tests/test_new_api.py
@@ -7,6 +7,7 @@ import lomap
 
 try:
     import gufe
+
     HAS_GUFE = True
 except ImportError:
     HAS_GUFE = False

--- a/src/lomap/tests/test_new_api.py
+++ b/src/lomap/tests/test_new_api.py
@@ -37,7 +37,7 @@ def basic():
 
 @pytest.mark.skipif(HAS_GUFE, reason="requires not having gufe installed")
 def test_generate_network_nogufe_failure():
-    msg = "gufe is required to use `generate_lomap_network`"
+    msg = "gufe is required to use `generate_lomap_network` but is not installed."
     with pytest.raises(ImportError, match=msg):
         _ = lomap.generate_lomap_network(
             ligands=None,

--- a/src/lomap/tests/test_new_api.py
+++ b/src/lomap/tests/test_new_api.py
@@ -37,7 +37,7 @@ def basic():
 
 @pytest.mark.skipif(HAS_GUFE, reason="requires not having gufe installed")
 def test_generate_network_nogufe_failure():
-    msg = "gufe is required to use generate_lomap_network"
+    msg = "gufe is required to use `generate_lomap_network`"
     with pytest.raises(ImportError, match=msg):
         _ = lomap.generate_lomap_network(
             ligands=None,

--- a/src/lomap/tests/test_new_api.py
+++ b/src/lomap/tests/test_new_api.py
@@ -34,6 +34,18 @@ def basic():
 
     return mols
 
+
+@pytest.mark.skipif(HAS_GUFE, reason="requires not having gufe installed")
+def test_generate_network_nogufe_failure():
+    msg = "gufe is required to use generate_lomap_network"
+    with pytest.raises(ImportError, match=msg):
+        _ = lomap.generate_lomap_network(
+            ligands=None,
+            mappers=None,
+            scorer=None,
+        )
+
+
 @pytest.mark.skipif(not HAS_GUFE, reason="requires gufe installed")
 def test_generate_network_smoketest(basic):
     with pytest.deprecated_call(match="'molecules' is deprecated, please use 'ligands'"):

--- a/src/lomap/tests/test_scorer.py
+++ b/src/lomap/tests/test_scorer.py
@@ -8,21 +8,22 @@ from rdkit import Chem
 import lomap
 from lomap import dbmol
 from lomap.gufe_bindings.scorers import (
+    atomic_number_score,
+    default_lomap_score,
     ecr_score,
+    heterocycles_score,
+    hybridization_score,
     mcsr_score,
     mncar_score,
-    tmcsr_score,
-    atomic_number_score,
-    hybridization_score,
     sulfonamides_score,
-    heterocycles_score,
+    tmcsr_score,
     transmuting_methyl_into_ring_score,
     transmuting_ring_sizes_score,
-    default_lomap_score,
 )
 
 try:
     import gufe
+
     HAS_GUFE = True
 except ImportError:
     HAS_GUFE = False
@@ -38,7 +39,8 @@ def smcs():
 
 
 @pytest.mark.skipif(HAS_GUFE, reason="requires not having gufe installed")
-@pytest.mark.parametrize("method", 
+@pytest.mark.parametrize(
+    "method",
     [
         ecr_score,
         mcsr_score,
@@ -51,7 +53,7 @@ def smcs():
         transmuting_methyl_into_ring_score,
         transmuting_ring_sizes_score,
         default_lomap_score,
-    ]
+    ],
 )
 def test_nogufe_errors(method):
     msg = f"gufe is required to use `{method.__qualname__}` but is not installed."

--- a/src/lomap/tests/test_scorer.py
+++ b/src/lomap/tests/test_scorer.py
@@ -43,7 +43,7 @@ def smcs():
         ecr_score,
         mcsr_score,
         mncar_score,
-        tmscr_score,
+        tmcsr_score,
         atomic_number_score,
         hybridization_score,
         sulfonamides_score,

--- a/src/lomap/tests/test_scorer.py
+++ b/src/lomap/tests/test_scorer.py
@@ -11,7 +11,7 @@ from lomap.gufe_bindings.scorers import (
     ecr_score,
     mcsr_score,
     mncar_score,
-    tmscr_score,
+    tmcsr_score,
     atomic_number_score,
     hybridization_score,
     sulfonamides_score,

--- a/src/lomap/tests/test_scorer.py
+++ b/src/lomap/tests/test_scorer.py
@@ -1,7 +1,6 @@
 import importlib.resources
 from functools import partial
 
-import gufe
 import pytest
 from numpy.testing import assert_equal
 from rdkit import Chem
@@ -9,6 +8,12 @@ from rdkit import Chem
 import lomap
 from lomap import dbmol
 from lomap.gufe_bindings.scorers import ecr_score
+
+try:
+    import gufe
+    HAS_GUFE = True
+except ImportError:
+    HAS_GUFE = False
 
 
 @pytest.fixture
@@ -20,6 +25,7 @@ def smcs():
     return mols
 
 
+@pytest.mark.skipif(not HAS_GUFE, reason="requires gufe installed")
 def test_unconnected_lomap_network(smcs):
     network = lomap.generate_lomap_network(
         molecules=smcs,
@@ -30,6 +36,7 @@ def test_unconnected_lomap_network(smcs):
     assert not network.is_connected()
 
 
+@pytest.mark.skipif(not HAS_GUFE, reason="requires gufe installed")
 def test_connected_lomap_network(smcs):
     # The default charge_changes_score is now 0.1, so a network of ligands
     # with different net charges should now always be connected
@@ -41,6 +48,7 @@ def test_connected_lomap_network(smcs):
     assert network.is_connected()
 
 
+@pytest.mark.skipif(not HAS_GUFE, reason="requires gufe installed")
 def test_ecr_consistency(smcs):
     lig_4 = [m for m in smcs if m.name == "lig_4"][0]
     other_mols = [m for m in smcs if m.name != "lig_4"]
@@ -62,6 +70,7 @@ def test_ecr_consistency(smcs):
     assert all([i == 0.1 for i in score_nonzero])
 
 
+@pytest.mark.skipif(not HAS_GUFE, reason="requires gufe installed")
 def test_default_and_explicit_charge_change_score_same(smcs):
     mapper = lomap.LomapAtomMapper()
     mapping = next(mapper.suggest_mappings(smcs[0], smcs[1]))

--- a/src/lomap/tests/test_scorer.py
+++ b/src/lomap/tests/test_scorer.py
@@ -7,7 +7,19 @@ from rdkit import Chem
 
 import lomap
 from lomap import dbmol
-from lomap.gufe_bindings.scorers import ecr_score
+from lomap.gufe_bindings.scorers import (
+    ecr_score,
+    mcsr_score,
+    mncar_score,
+    tmscr_score,
+    atomic_number_score,
+    hybridization_score,
+    sulfonamides_score,
+    heterocycles_score,
+    transmuting_methyl_into_ring_score,
+    transmuting_ring_sizes_score,
+    default_lomap_score,
+)
 
 try:
     import gufe
@@ -23,6 +35,28 @@ def smcs():
     rdmols = [mol for mol in Chem.SDMolSupplier(str(fns), removeHs=False)]
     mols = [gufe.SmallMoleculeComponent.from_rdkit(mol) for mol in rdmols]
     return mols
+
+
+@pytest.mark.skipif(HAS_GUFE, reason="requires not having gufe installed")
+@pytest.mark.parametrize("method", 
+    [
+        ecr_score,
+        mcsr_score,
+        mncar_score,
+        tmscr_score,
+        atomic_number_score,
+        hybridization_score,
+        sulfonamides_score,
+        heterocycles_score,
+        transmuting_methyl_into_ring_score,
+        transmuting_ring_sizes_score,
+        default_lomap_score,
+    ]
+)
+def test_nogufe_errors(method):
+    msg = f"gufe is required to use `{method.__qualname__}`"
+    with pytest.raises(ImportError, match=msg):
+        _ = method(mapping=None)
 
 
 @pytest.mark.skipif(not HAS_GUFE, reason="requires gufe installed")

--- a/src/lomap/tests/test_scorer.py
+++ b/src/lomap/tests/test_scorer.py
@@ -54,7 +54,7 @@ def smcs():
     ]
 )
 def test_nogufe_errors(method):
-    msg = f"gufe is required to use `{method.__qualname__}`"
+    msg = f"gufe is required to use `{method.__qualname__}` but is not installed."
     with pytest.raises(ImportError, match=msg):
         _ = method(mapping=None)
 

--- a/src/lomap/utils.py
+++ b/src/lomap/utils.py
@@ -84,10 +84,7 @@ def requires_package(package_name: str) -> Callable:
         if available:
             return obj
 
-        msg = (
-            f"{package_name} is required to use `{obj.__qualname__}` "
-            "but is not installed."
-        )
+        msg = f"{package_name} is required to use `{obj.__qualname__}` but is not installed."
 
         if inspect.isclass(obj):
             original_init = obj.__init__
@@ -100,6 +97,7 @@ def requires_package(package_name: str) -> Callable:
             return obj
 
         else:
+
             @functools.wraps(obj)
             def wrapper(*args, **kwargs):
                 raise ImportError(msg)

--- a/src/lomap/utils.py
+++ b/src/lomap/utils.py
@@ -1,4 +1,6 @@
 import functools
+import importlib
+import inspect
 import warnings
 from collections.abc import Callable
 from typing import Any
@@ -41,5 +43,67 @@ def deprecated_kwargs(name_mappings: dict[str, str]) -> Callable:
             return func(*args, **kwargs)
 
         return wrapper
+
+    return decorator
+
+
+def requires_package(package_name: str) -> Callabe:
+    """
+    Decorator that raises an ImportError if a class or function
+    is used and ``package_name`` is not available.
+
+    Parameters
+    ----------
+    package_name : str
+      Name of the required package (e.g. "gufe")
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+       @requires_package("gufe")
+       def my function(): ...
+
+       @requires_package("gufe")
+       class MyClass: ...
+
+    Notes
+    -----
+    For classes, this decorator effectively decorates the ``__init__``
+    method but can be used on the class constructor directly.
+    """
+    try:
+        importlib.import_module(package_name)
+        available = True
+    except ImportError:
+        available = False
+
+    def decorator(obj):
+
+        if available:
+            return obj
+
+        msg = (
+            f"{package_name} is required to use `{obj.__qualname__}` "
+            "but is not installed."
+        )
+
+        if inspect.isclass(obj):
+            original_init = obj.__init__
+
+            @functools.wraps(original_init)
+            def _init(self, *args, **kwargs):
+                raise ImportError(msg)
+
+            obj.__init__ = _init
+            return obj
+
+        else:
+            @functools.wraps(obj)
+            def wrapper(*args, **kwargs):
+                raise ImportError(msg)
+
+            return wrapper
 
     return decorator

--- a/src/lomap/utils.py
+++ b/src/lomap/utils.py
@@ -47,7 +47,7 @@ def deprecated_kwargs(name_mappings: dict[str, str]) -> Callable:
     return decorator
 
 
-def requires_package(package_name: str) -> Callabe:
+def requires_package(package_name: str) -> Callable:
     """
     Decorator that raises an ImportError if a class or function
     is used and ``package_name`` is not available.


### PR DESCRIPTION
Fixes #104 

Makes `gufe` an optional dependency and all gufe-bindings to raise NotImportedErrors if they are called without gufe being installed.

LLM disclaimer: used help from Claude Sonet 4.6 to expand the `requires_package` to also cover classes.