### PR TITLE
Add dependencies back into pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,12 @@ dependencies = [
   "numpy",
   "rdkit",
 ]
+optional-dependencies.credits = [ "duecredit" ]
 optional-dependencies.graphviz = [ "pygraphviz" ]
 optional-dependencies.test = [
   "codecov",
   "pytest",
 ]
-optional-dependencies.credits = [ "duecredit" ]
 urls = { Homepage = "https://github.com/OpenFreeEnergy/Lomap" }
 scripts.lomap = "lomap.dbmol:startup"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,12 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics",
 ]
 dynamic = [ "version" ]
+dependencies = [
+  "networkx",
+  "numpy",
+  "rdkit",
+  "matplotlib",
+]
 optional-dependencies.graphviz = [ "pygraphviz" ]
 optional-dependencies.test = [
   "codecov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ optional-dependencies.test = [
   "codecov",
   "pytest",
 ]
+optional-dependencies.credits = [ "duecredit" ]
 urls = { Homepage = "https://github.com/OpenFreeEnergy/Lomap" }
 scripts.lomap = "lomap.dbmol:startup"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,10 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 dependencies = [
+  "matplotlib",
   "networkx",
   "numpy",
   "rdkit",
-  "matplotlib",
 ]
 optional-dependencies.graphviz = [ "pygraphviz" ]
 optional-dependencies.test = [


### PR DESCRIPTION
Fixes #92 

Now that gufe is no longer a required dependency, we can update pyproject.toml with its main dependencies.
Note: I am not adding gufe as an optional dep to the pyproject.toml either because that would run the risk of picking up a bad pypi upload.